### PR TITLE
[Security] Add app and access tokens

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,53 +1,95 @@
 import restify from 'restify'
 import AWS from 'aws-sdk'
 import request from 'request'
-import { config } from './config.js'
+import { config } from './config'
+import {
+  isTokenValid,
+  createAccessToken,
+  createTestAppToken,
+} from './token'
 
 const server = restify.createServer()
 server.use(restify.plugins.bodyParser())
+server.use(restify.plugins.queryParser());
 const port = process.env.PORT || 8080
 
-server.get('/test', (req, res, next) => {
-  const getRandomInt = max => Math.floor(Math.random() * Math.floor(max))
-  const params = {
-    MetricData: [
-      {
-        MetricName: 'HELLO_WORLD',
-        Value: getRandomInt(100),
-      }
-    ],
-    Namespace: 'cloudwatch-postman',
+server.post('/token', (req, res, next) => {
+  const appToken = req.body.appToken
+
+  if (isTokenValid(appToken)) {
+    const response = {
+      accessToken: createAccessToken(),
+    }
+
+    res.send(201, { response })
+  } else {
+    res.send(403, { error: 'Your application token is invalid!' })
   }
 
-  request.post({
-    url: `http://localhost:${port}/metric`,
-    body: JSON.stringify(params),
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  }, (error, response, body) => {
-    console.log('error:', error)
-    console.log('statusCode:', response && response.statusCode)
-    res.send(body)
-  })
+  next()
+})
+
+server.get('/test', (req, res, next) => {
+  const appToken = req.query.appToken
+
+  if (isTokenValid(appToken)) {
+    const accessToken = createAccessToken()
+    const getRandomInt = max => Math.floor(Math.random() * Math.floor(max))
+    const params = {
+      accessToken,
+      params: {
+        MetricData: [
+        {
+            MetricName: 'HELLO_WORLD',
+            Value: getRandomInt(100),
+          }
+        ],
+        Namespace: 'cloudwatch-postman',
+      }
+    }
+
+    request.post({
+      url: `http://localhost:${port}/metric`,
+      body: JSON.stringify(params),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }, (error, response, body) => {
+      console.log('error:', error)
+      console.log('statuscode:', response && response.statusCode)
+      res.send(body)
+    })
+  } else {
+    res.send(403, { error: 'Your application token is invalid!' })
+  }
 
   next()
 })
 
 server.post('/metric', (req, res, next) => {
+  const { body: { accessToken, params } } = req
   const cloudwatch = new AWS.CloudWatch({
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
     region: process.env.AWS_REGION,
   })
 
-  cloudwatch.putMetricData(req.body, (err, data) => {
-    if (err) {
-      return console.log(err, err.stack)
-    }
+  if (isTokenValid(accessToken)) {
+    cloudwatch.putMetricData(req.body.params, (err, data) => {
+      if (err) {
+        return console.log(err, err.stack)
+      }
 
-    res.send(data)
-  })
+      res.send(data)
+    })
+  } else {
+    res.send(
+      403,
+      {
+        error: 'Your access token is invalid! Please generated a new one with your application token.',
+      }
+    )
+  }
 
   next()
 })

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,8 @@ import AWS from 'aws-sdk'
 import request from 'request'
 import { config } from './config'
 import {
-  isTokenValid,
+  isAppTokenValid,
+  isAccessTokenValid,
   createAccessToken,
   createTestAppToken,
 } from './token'
@@ -38,7 +39,7 @@ server.get('/test', (req, res, next) => {
     return next()
   }
 
-  if (!isTokenValid(appToken)) {
+  if (!isAppTokenValid(appToken)) {
     res.send(401, invalidAppTokenErrorBody, headers)
     return next()
   }
@@ -83,7 +84,7 @@ server.post('/token', (req, res, next) => {
 
   const appToken = req.body.appToken
 
-  if (!isTokenValid(appToken)) {
+  if (!isAppTokenValid(appToken)) {
     res.send(401, invalidAppTokenErrorBody, headers)
     return next()
   }
@@ -111,7 +112,7 @@ server.post('/metric', (req, res, next) => {
     return next()
   }
 
-  if (!isTokenValid(accessToken)) {
+  if (!isAccessTokenValid(accessToken)) {
     const errorBody = JSON.stringify({
       error: {
         code: 111,

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,86 +12,130 @@ const server = restify.createServer()
 server.use(restify.plugins.bodyParser())
 server.use(restify.plugins.queryParser());
 const port = process.env.PORT || 8080
+const headers = {
+  'Content-Type': 'application/json',
+}
 
-server.post('/token', (req, res, next) => {
-  const appToken = req.body.appToken
+const invalidAppTokenErrorBody = JSON.stringify({
+  error: {
+    code: 101,
+    message: 'Required parameter "appToken" is invalid.',
+  },
+})
 
-  if (isTokenValid(appToken)) {
-    const response = {
-      accessToken: createAccessToken(),
-    }
-
-    res.send(201, { response })
-  } else {
-    res.send(403, { error: 'Your application token is invalid!' })
-  }
-
-  next()
+const noAppTokenErrorBody = JSON.stringify({
+  error: {
+    code: 100,
+    message: 'Required parameter is missing: "appToken".',
+  },
 })
 
 server.get('/test', (req, res, next) => {
   const appToken = req.query.appToken
 
-  if (isTokenValid(appToken)) {
-    const accessToken = createAccessToken()
-    const getRandomInt = max => Math.floor(Math.random() * Math.floor(max))
-    const params = {
-      accessToken,
-      params: {
-        MetricData: [
-        {
-            MetricName: 'HELLO_WORLD',
-            Value: getRandomInt(100),
-          }
-        ],
-        Namespace: 'cloudwatch-postman',
-      }
-    }
-
-    request.post({
-      url: `http://localhost:${port}/metric`,
-      body: JSON.stringify(params),
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    }, (error, response, body) => {
-      console.log('error:', error)
-      console.log('statuscode:', response && response.statusCode)
-      res.send(body)
-    })
-  } else {
-    res.send(403, { error: 'Your application token is invalid!' })
+  if (!appToken) {
+    res.send(403, noAppTokenErrorBody, headers)
+    return next()
   }
 
-  next()
+  if (!isTokenValid(appToken)) {
+    res.send(401, invalidAppTokenErrorBody, headers)
+    return next()
+  }
+
+  const accessToken = createAccessToken()
+  const getRandomInt = max => Math.floor(Math.random() * Math.floor(max))
+  const params = {
+    accessToken,
+    params: {
+      MetricData: [
+      {
+          MetricName: 'HELLO_WORLD',
+          Value: getRandomInt(100),
+        }
+      ],
+      Namespace: 'cloudwatch-postman',
+    }
+  }
+
+  request.post({
+    url: `http://localhost:${port}/metric`,
+    body: JSON.stringify(params),
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+  }, (error, response, body) => {
+    if (error) console.log('>> Error:', error)
+    if (response) console.log('>> Status code:', response.statusCode)
+
+    res.send(200, JSON.parse(body), headers)
+  })
+
+  return next()
+})
+
+server.post('/token', (req, res, next) => {
+  if (!req.body || !req.body.appToken) {
+    res.send(403, noAppTokenErrorBody, headers)
+    return next()
+  }
+
+  const appToken = req.body.appToken
+
+  if (!isTokenValid(appToken)) {
+    res.send(401, invalidAppTokenErrorBody, headers)
+    return next()
+  }
+
+  const response = JSON.stringify({
+    accessToken: createAccessToken(),
+  })
+
+  res.send(201, response, headers)
+  return next()
 })
 
 server.post('/metric', (req, res, next) => {
   const { body: { accessToken, params } } = req
+
+  if (!accessToken) {
+    const errorBody = JSON.stringify({
+      error: {
+        code: 110,
+        message: 'Required parameter is missing: "accessToken".',
+      }
+    })
+
+    res.send(403, errorBody, headers)
+    return next()
+  }
+
+  if (!isTokenValid(accessToken)) {
+    const errorBody = JSON.stringify({
+      error: {
+        code: 111,
+        message: 'Required parameter "accessToken" is invalid.',
+      }
+    })
+
+    res.send(401, errorBody, headers)
+    return next()
+  }
+
   const cloudwatch = new AWS.CloudWatch({
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
     region: process.env.AWS_REGION,
   })
 
-  if (isTokenValid(accessToken)) {
-    cloudwatch.putMetricData(req.body.params, (err, data) => {
-      if (err) {
-        return console.log(err, err.stack)
-      }
+  cloudwatch.putMetricData(req.body.params, (err, data) => {
+    if (err) return console.log(err, err.stack)
 
-      res.send(data)
-    })
-  } else {
-    res.send(
-      403,
-      {
-        error: 'Your access token is invalid! Please generated a new one with your application token.',
-      }
-    )
-  }
+    res.send(201, data, headers)
+  })
 
-  next()
+  return next()
 })
 
 server.listen(port, () => {

--- a/lib/token.js
+++ b/lib/token.js
@@ -1,0 +1,48 @@
+import crypto from 'crypto'
+
+export const generateSalt = length => (
+  crypto
+    .randomBytes(length)
+    .toString('hex')
+)
+
+export const generateHash = data => crypto.createHash('sha256').update(data)
+export const generateToken = (tokenItems, delimiter) => {
+  return Buffer
+    .from(tokenItems.join(delimiter))
+    .toString('base64')
+}
+
+export const isAppTokenExpired = (tokenTimestamp) => {
+  const today = new Date()
+  const tokenDate = new Date(tokenTimestamp)
+  const tokenExpirationDate = new Date(tokenTimestamp)
+  tokenExpirationDate.setDate(tokenDate.getDate() + 1)
+
+  return tokenExpirationDate.getTime() > today.getTime()
+}
+
+export const isTokenValid = (token) => {
+  const data = Buffer.from(token, 'base64')
+  const decodedData = data.toString('ascii')
+  const apiSecret = process.env.CLOUDWATCH_POSTMAN_SECRET_KEY
+
+  const [ date, salt, secret ] = decodedData.split('::')
+
+  if (isAppTokenExpired(date)) return false
+
+  const apiHash = generateHash(`${date}${salt}${apiSecret}`).digest('base64')
+  const providedHash = generateHash(`${date}${salt}${secret}`).digest('base64')
+
+  return apiHash == providedHash
+}
+
+export const createAccessToken = () => {
+  const date = new Date().getTime()
+  const salt = generateSalt(12)
+  const secret = process.env.CLOUDWATCH_POSTMAN_SECRET_KEY
+  const delimiter = '::'
+  const hash = generateHash(`${date}${salt}${secret}`)
+
+  return generateToken([date, salt, secret], delimiter)
+}

--- a/lib/token.js
+++ b/lib/token.js
@@ -1,11 +1,6 @@
 import crypto from 'crypto'
 
-export const generateSalt = length => (
-  crypto
-    .randomBytes(length)
-    .toString('hex')
-)
-
+export const generateSalt = length => crypto.randomBytes(length).toString('hex')
 export const generateHash = data => crypto.createHash('sha256').update(data)
 export const generateToken = (tokenItems, delimiter) => {
   return Buffer
@@ -13,23 +8,46 @@ export const generateToken = (tokenItems, delimiter) => {
     .toString('base64')
 }
 
-export const isAppTokenExpired = (tokenTimestamp) => {
+export const isTokenExpired = (tokenTimestamp, expiration = { day: 1 }) => {
   const today = new Date()
   const tokenDate = new Date(tokenTimestamp)
   const tokenExpirationDate = new Date(tokenTimestamp)
-  tokenExpirationDate.setDate(tokenDate.getDate() + 1)
+  const { day, hour } = expiration
 
-  return tokenExpirationDate.getTime() > today.getTime()
+  if (day) {
+    tokenExpirationDate.setDate(tokenDate.getDate() + day)
+  }
+
+  if (hour) {
+    tokenExpirationDate.setHours(tokenDate.getHours() + hour)
+  }
+
+  return tokenExpirationDate.getTime() < today.getTime()
 }
 
-export const isTokenValid = (token) => {
+export const isAccessTokenValid = (token) => {
   const data = Buffer.from(token, 'base64')
   const decodedData = data.toString('ascii')
-  const apiSecret = process.env.CLOUDWATCH_POSTMAN_SECRET_KEY
+  const apiSecret = process.env.ACCESS_TOKEN_SECRET_KEY
 
   const [ date, salt, secret ] = decodedData.split('::')
 
-  if (isAppTokenExpired(date)) return false
+  if (isTokenExpired(+date, { hour: 1 })) return false
+
+  const apiHash = generateHash(`${date}${salt}${apiSecret}`).digest('base64')
+  const providedHash = generateHash(`${date}${salt}${secret}`).digest('base64')
+
+  return apiHash == providedHash
+}
+
+export const isAppTokenValid = (token) => {
+  const data = Buffer.from(token, 'base64')
+  const decodedData = data.toString('ascii')
+  const apiSecret = process.env.APP_SECRET_KEY
+
+  const [ date, salt, secret ] = decodedData.split('::')
+
+  if (isTokenExpired(+date)) return false
 
   const apiHash = generateHash(`${date}${salt}${apiSecret}`).digest('base64')
   const providedHash = generateHash(`${date}${salt}${secret}`).digest('base64')
@@ -40,7 +58,7 @@ export const isTokenValid = (token) => {
 export const createAccessToken = () => {
   const date = new Date().getTime()
   const salt = generateSalt(12)
-  const secret = process.env.CLOUDWATCH_POSTMAN_SECRET_KEY
+  const secret = process.env.ACCESS_TOKEN_SECRET_KEY
   const delimiter = '::'
   const hash = generateHash(`${date}${salt}${secret}`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4375,6 +4375,12 @@
         "supports-color": "^5.5.0"
       }
     },
+    "sinon-chai": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.3.0.tgz",
+      "integrity": "sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA==",
+      "dev": true
+    },
     "slash": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "aws-sdk-mock": "^4.4.0",
     "chai": "^4.2.0",
     "chai-http": "^4.3.0",
-    "mocha": "^6.1.4"
+    "mocha": "^6.1.4",
+    "sinon": "^7.3.2",
+    "sinon-chai": "^3.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "npm run build && node dist/index.js",
     "serve": "npm run build && node -r dotenv/config dist/index.js",
     "test": "BABEL_ENV=test NODE_ENV=test mocha --require @babel/register",
-    "dev:test": "npm run build && BABEL_ENV=test NODE_ENV=test mocha -r @babel/register -r dotenv/config"
+    "dev:test": "BABEL_ENV=test NODE_ENV=test mocha -r @babel/register -r dotenv/config"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "npm run build && node dist/index.js",
     "serve": "npm run build && node -r dotenv/config dist/index.js",
     "test": "BABEL_ENV=test NODE_ENV=test mocha --require @babel/register",
-    "dev:test": "BABEL_ENV=test NODE_ENV=test mocha -r @babel/register -r dotenv/config"
+    "dev:test": "npm run build && BABEL_ENV=test NODE_ENV=test mocha -r @babel/register -r dotenv/config"
   },
   "repository": {
     "type": "git",

--- a/test/index.js
+++ b/test/index.js
@@ -25,7 +25,7 @@ export const createTestAppToken = () => {
 
 beforeEach(() => {
   AWS.mock('CloudWatch', 'putMetricData', function (params, callback){
-    callback(null, 'ok');
+    callback(null, "{\"ResponseMetadata\":{\"RequestId\":\"foobar\"}}")
   });
 })
 
@@ -34,42 +34,223 @@ afterEach(() => {
 })
 
 describe('GET /test', () => {
-  it('returns a response', (done) => {
-    const appToken = createTestAppToken()
-    chai.request(server)
-      .get(`/test?appToken=${appToken}`)
-      .end((err, res) => {
-        expect(res.status).to.eq(200)
-        expect(JSON.parse(res.body)).to.eq('ok')
-        done()
-      })
+  describe('with a valid app token', () => {
+    it('returns a 200 with a data object', (done) => {
+      const appToken = createTestAppToken()
+
+      chai.request(server)
+        .get(`/test?appToken=${appToken}`)
+        .end((err, res) => {
+          const { status, body } = res
+          const response = JSON.parse(body)
+
+          expect(status).to.eq(200)
+          expect(response.ResponseMetadata.RequestId).to.eq('foobar')
+
+          done()
+        })
+    })
+  })
+
+  describe('with an invalid app token', () => {
+    it('returns a 401 with an error object', (done) => {
+      const appToken = 'aliceInWonderland'
+
+      chai.request(server)
+        .get(`/test?appToken=${appToken}`)
+        .end((err, res) => {
+          const { status, body } = res
+          const response = JSON.parse(body)
+
+          expect(status).to.eq(401)
+          expect(response.error.code).to.eq(101)
+          expect(response.error.message)
+            .to.eq('Required parameter "appToken" is invalid.')
+
+          done()
+        })
+    })
+  })
+
+  describe('without an app token', () => {
+    it('returns a 403 with an error object', (done) => {
+      chai.request(server)
+        .get('/test')
+        .end((err, res) => {
+          const { status, body } = res
+          const response = JSON.parse(body)
+
+          expect(status).to.eq(403)
+          expect(response.error.code).to.eq(100)
+          expect(response.error.message)
+            .to.eq('Required parameter is missing: "appToken".')
+
+          done()
+        })
+    })
+  })
+})
+
+describe('POST /token', () => {
+  describe('with a valid app token', () => {
+    it('returns a 201 with the newly created access token', (done) => {
+      const appToken = createTestAppToken()
+
+      chai.request(server)
+        .post('/token')
+        .set('Content-Type', 'application/json')
+        .send(JSON.stringify({ appToken }))
+        .end((err, res) => {
+          const { status, body } = res
+          const response = JSON.parse(body)
+
+          expect(status).to.eq(201)
+          expect(response).to.have.key('accessToken')
+
+          done()
+        })
+    })
+  })
+
+  describe('with an invalid app token', () => {
+    it('returns a 401 with an error object', (done) => {
+      const appToken = 'aliceInWonderland'
+
+      chai.request(server)
+        .post('/token')
+        .set('Content-Type', 'application/json')
+        .send(JSON.stringify({ appToken }))
+        .end((err, res) => {
+          const { status, body } = res
+          const response = JSON.parse(body)
+
+          expect(status).to.eq(401)
+          expect(response.error.code).to.eq(101)
+          expect(response.error.message)
+            .to.eq('Required parameter "appToken" is invalid.')
+
+          done()
+        })
+    })
+  })
+
+  describe('without an app token', () => {
+    it('returns a 403 with an error object', (done) => {
+      chai.request(server)
+        .post('/token')
+        .set('Content-Type', 'application/json')
+        .end((err, res) => {
+          const { status, body } = res
+          const response = JSON.parse(body)
+
+          expect(status).to.eq(403)
+          expect(response.error.code).to.eq(100)
+          expect(response.error.message)
+            .to.eq('Required parameter is missing: "appToken".')
+
+          done()
+        })
+    })
   })
 })
 
 describe('POST /metric', () => {
-  it('returns a response', (done) => {
-    const accessToken = createAccessToken()
-    const params = {
-      accessToken,
-      params: {
-        MetricData: [
-          {
-            MetricName: 'HELLO_WORLD',
-            Value: 100,
-          }
-        ],
-        Namespace: 'cloudwatch-postman',
+  describe('with a valid access token', () => {
+    it('returns a response', (done) => {
+      const accessToken = createAccessToken()
+      const params = {
+        accessToken,
+        params: {
+          MetricData: [
+            {
+              MetricName: 'HELLO_WORLD',
+              Value: 100,
+            }
+          ],
+          Namespace: 'cloudwatch-postman',
+        }
       }
-    }
 
-    chai.request(server)
-      .post('/metric')
-      .set('Content-Type', 'application/json')
-      .send(JSON.stringify(params))
-      .end((err, res) => {
-        expect(res.status).to.eq(200)
-        expect(res.body).to.eq('ok')
-        done()
-      })
+      chai.request(server)
+        .post('/metric')
+        .set('Content-Type', 'application/json')
+        .send(JSON.stringify(params))
+        .end((err, res) => {
+          const { status, body } = res
+          const response = JSON.parse(body)
+
+          expect(status).to.eq(201)
+          expect(response.ResponseMetadata.RequestId).to.eq('foobar')
+
+          done()
+        })
+    })
+  })
+
+  describe('with an invalid access token', () => {
+    it('returns a 401 with an error object', (done) => {
+      const accessToken = 'aliceInWonderland'
+
+      const params = {
+        accessToken,
+        params: {
+          MetricData: [
+            {
+              MetricName: 'HELLO_WORLD',
+              Value: 100,
+            }
+          ],
+          Namespace: 'cloudwatch-postman',
+        }
+      }
+
+      chai.request(server)
+        .post('/metric')
+        .set('Content-Type', 'application/json')
+        .send(JSON.stringify(params))
+        .end((err, res) => {
+          const { status, body } = res
+          const response = JSON.parse(body)
+
+          expect(status).to.eq(401)
+          expect(response.error.code).to.eq(111)
+          expect(response.error.message)
+            .to.eq('Required parameter "accessToken" is invalid.')
+
+          done()
+        })
+    })
+  })
+
+  describe('without an access token', () => {
+    it('returns a 403 with an error object', (done) => {
+      const params = {
+        params: {
+          MetricData: [
+            {
+              MetricName: 'HELLO_WORLD',
+              Value: 100,
+            }
+          ],
+          Namespace: 'cloudwatch-postman',
+        }
+      }
+
+      chai.request(server)
+        .post('/metric')
+        .set('Content-Type', 'application/json')
+        .send(JSON.stringify(params))
+        .end((err, res) => {
+          const { status, body } = res
+          const response = JSON.parse(body)
+
+          expect(status).to.eq(403)
+          expect(response.error.code).to.eq(110)
+          expect(response.error.message)
+            .to.eq('Required parameter is missing: "accessToken".')
+
+          done()
+        })
+    })
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -16,241 +16,243 @@ chai.use(chaiHttp)
 export const createTestAppToken = () => {
   const date = new Date().getTime()
   const salt = generateSalt(8)
-  const secret = process.env.CLOUDWATCH_POSTMAN_SECRET_KEY
+  const secret = process.env.APP_SECRET_KEY
   const delimiter = '::'
   const hash = generateHash(`${date}${salt}${secret}`)
 
   return generateToken([date, salt, secret], delimiter)
 }
 
-beforeEach(() => {
-  AWS.mock('CloudWatch', 'putMetricData', function (params, callback){
-    callback(null, "{\"ResponseMetadata\":{\"RequestId\":\"foobar\"}}")
-  });
-})
+describe('=========== index.js ==========', () => {
+  beforeEach(() => {
+    AWS.mock('CloudWatch', 'putMetricData', function (params, callback){
+      callback(null, "{\"ResponseMetadata\":{\"RequestId\":\"foobar\"}}")
+    });
+  })
 
-afterEach(() => {
-  AWS.restore('CloudWatch')
-})
+  afterEach(() => {
+    AWS.restore('CloudWatch')
+  })
 
-describe('GET /test', () => {
-  describe('with a valid app token', () => {
-    it('returns a 200 with a data object', (done) => {
-      const appToken = createTestAppToken()
+  describe('GET /test', () => {
+    describe('with a valid app token', () => {
+      it('returns a 200 with a data object', (done) => {
+        const appToken = createTestAppToken()
 
-      chai.request(server)
-        .get(`/test?appToken=${appToken}`)
-        .end((err, res) => {
-          const { status, body } = res
-          const response = JSON.parse(body)
+        chai.request(server)
+          .get(`/test?appToken=${appToken}`)
+          .end((err, res) => {
+            const { status, body } = res
+            const response = JSON.parse(body)
 
-          expect(status).to.eq(200)
-          expect(response.ResponseMetadata.RequestId).to.eq('foobar')
+            expect(status).to.eq(200)
+            expect(response.ResponseMetadata.RequestId).to.eq('foobar')
 
-          done()
-        })
+            done()
+          })
+      })
+    })
+
+    describe('with an invalid app token', () => {
+      it('returns a 401 with an error object', (done) => {
+        const appToken = 'aliceInWonderland'
+
+        chai.request(server)
+          .get(`/test?appToken=${appToken}`)
+          .end((err, res) => {
+            const { status, body } = res
+            const response = JSON.parse(body)
+
+            expect(status).to.eq(401)
+            expect(response.error.code).to.eq(101)
+            expect(response.error.message)
+              .to.eq('Required parameter "appToken" is invalid.')
+
+            done()
+          })
+      })
+    })
+
+    describe('without an app token', () => {
+      it('returns a 403 with an error object', (done) => {
+        chai.request(server)
+          .get('/test')
+          .end((err, res) => {
+            const { status, body } = res
+            const response = JSON.parse(body)
+
+            expect(status).to.eq(403)
+            expect(response.error.code).to.eq(100)
+            expect(response.error.message)
+              .to.eq('Required parameter is missing: "appToken".')
+
+            done()
+          })
+      })
     })
   })
 
-  describe('with an invalid app token', () => {
-    it('returns a 401 with an error object', (done) => {
-      const appToken = 'aliceInWonderland'
+  describe('POST /token', () => {
+    describe('with a valid app token', () => {
+      it('returns a 201 with the newly created access token', (done) => {
+        const appToken = createTestAppToken()
 
-      chai.request(server)
-        .get(`/test?appToken=${appToken}`)
-        .end((err, res) => {
-          const { status, body } = res
-          const response = JSON.parse(body)
+        chai.request(server)
+          .post('/token')
+          .set('Content-Type', 'application/json')
+          .send(JSON.stringify({ appToken }))
+          .end((err, res) => {
+            const { status, body } = res
+            const response = JSON.parse(body)
 
-          expect(status).to.eq(401)
-          expect(response.error.code).to.eq(101)
-          expect(response.error.message)
-            .to.eq('Required parameter "appToken" is invalid.')
+            expect(status).to.eq(201)
+            expect(response).to.have.key('accessToken')
 
-          done()
-        })
+            done()
+          })
+      })
+    })
+
+    describe('with an invalid app token', () => {
+      it('returns a 401 with an error object', (done) => {
+        const appToken = 'aliceInWonderland'
+
+        chai.request(server)
+          .post('/token')
+          .set('Content-Type', 'application/json')
+          .send(JSON.stringify({ appToken }))
+          .end((err, res) => {
+            const { status, body } = res
+            const response = JSON.parse(body)
+
+            expect(status).to.eq(401)
+            expect(response.error.code).to.eq(101)
+            expect(response.error.message)
+              .to.eq('Required parameter "appToken" is invalid.')
+
+            done()
+          })
+      })
+    })
+
+    describe('without an app token', () => {
+      it('returns a 403 with an error object', (done) => {
+        chai.request(server)
+          .post('/token')
+          .set('Content-Type', 'application/json')
+          .end((err, res) => {
+            const { status, body } = res
+            const response = JSON.parse(body)
+
+            expect(status).to.eq(403)
+            expect(response.error.code).to.eq(100)
+            expect(response.error.message)
+              .to.eq('Required parameter is missing: "appToken".')
+
+            done()
+          })
+      })
     })
   })
 
-  describe('without an app token', () => {
-    it('returns a 403 with an error object', (done) => {
-      chai.request(server)
-        .get('/test')
-        .end((err, res) => {
-          const { status, body } = res
-          const response = JSON.parse(body)
-
-          expect(status).to.eq(403)
-          expect(response.error.code).to.eq(100)
-          expect(response.error.message)
-            .to.eq('Required parameter is missing: "appToken".')
-
-          done()
-        })
-    })
-  })
-})
-
-describe('POST /token', () => {
-  describe('with a valid app token', () => {
-    it('returns a 201 with the newly created access token', (done) => {
-      const appToken = createTestAppToken()
-
-      chai.request(server)
-        .post('/token')
-        .set('Content-Type', 'application/json')
-        .send(JSON.stringify({ appToken }))
-        .end((err, res) => {
-          const { status, body } = res
-          const response = JSON.parse(body)
-
-          expect(status).to.eq(201)
-          expect(response).to.have.key('accessToken')
-
-          done()
-        })
-    })
-  })
-
-  describe('with an invalid app token', () => {
-    it('returns a 401 with an error object', (done) => {
-      const appToken = 'aliceInWonderland'
-
-      chai.request(server)
-        .post('/token')
-        .set('Content-Type', 'application/json')
-        .send(JSON.stringify({ appToken }))
-        .end((err, res) => {
-          const { status, body } = res
-          const response = JSON.parse(body)
-
-          expect(status).to.eq(401)
-          expect(response.error.code).to.eq(101)
-          expect(response.error.message)
-            .to.eq('Required parameter "appToken" is invalid.')
-
-          done()
-        })
-    })
-  })
-
-  describe('without an app token', () => {
-    it('returns a 403 with an error object', (done) => {
-      chai.request(server)
-        .post('/token')
-        .set('Content-Type', 'application/json')
-        .end((err, res) => {
-          const { status, body } = res
-          const response = JSON.parse(body)
-
-          expect(status).to.eq(403)
-          expect(response.error.code).to.eq(100)
-          expect(response.error.message)
-            .to.eq('Required parameter is missing: "appToken".')
-
-          done()
-        })
-    })
-  })
-})
-
-describe('POST /metric', () => {
-  describe('with a valid access token', () => {
-    it('returns a response', (done) => {
-      const accessToken = createAccessToken()
-      const params = {
-        accessToken,
-        params: {
-          MetricData: [
-            {
-              MetricName: 'HELLO_WORLD',
-              Value: 100,
-            }
-          ],
-          Namespace: 'cloudwatch-postman',
+  describe('POST /metric', () => {
+    describe('with a valid access token', () => {
+      it('returns a response', (done) => {
+        const accessToken = createAccessToken()
+        const params = {
+          accessToken,
+          params: {
+            MetricData: [
+              {
+                MetricName: 'HELLO_WORLD',
+                Value: 100,
+              }
+            ],
+            Namespace: 'cloudwatch-postman',
+          }
         }
-      }
 
-      chai.request(server)
-        .post('/metric')
-        .set('Content-Type', 'application/json')
-        .send(JSON.stringify(params))
-        .end((err, res) => {
-          const { status, body } = res
-          const response = JSON.parse(body)
+        chai.request(server)
+          .post('/metric')
+          .set('Content-Type', 'application/json')
+          .send(JSON.stringify(params))
+          .end((err, res) => {
+            const { status, body } = res
+            const response = JSON.parse(body)
 
-          expect(status).to.eq(201)
-          expect(response.ResponseMetadata.RequestId).to.eq('foobar')
+            expect(status).to.eq(201)
+            expect(response.ResponseMetadata.RequestId).to.eq('foobar')
 
-          done()
-        })
+            done()
+          })
+      })
     })
-  })
 
-  describe('with an invalid access token', () => {
-    it('returns a 401 with an error object', (done) => {
-      const accessToken = 'aliceInWonderland'
+    describe('with an invalid access token', () => {
+      it('returns a 401 with an error object', (done) => {
+        const accessToken = 'aliceInWonderland'
 
-      const params = {
-        accessToken,
-        params: {
-          MetricData: [
-            {
-              MetricName: 'HELLO_WORLD',
-              Value: 100,
-            }
-          ],
-          Namespace: 'cloudwatch-postman',
+        const params = {
+          accessToken,
+          params: {
+            MetricData: [
+              {
+                MetricName: 'HELLO_WORLD',
+                Value: 100,
+              }
+            ],
+            Namespace: 'cloudwatch-postman',
+          }
         }
-      }
 
-      chai.request(server)
-        .post('/metric')
-        .set('Content-Type', 'application/json')
-        .send(JSON.stringify(params))
-        .end((err, res) => {
-          const { status, body } = res
-          const response = JSON.parse(body)
+        chai.request(server)
+          .post('/metric')
+          .set('Content-Type', 'application/json')
+          .send(JSON.stringify(params))
+          .end((err, res) => {
+            const { status, body } = res
+            const response = JSON.parse(body)
 
-          expect(status).to.eq(401)
-          expect(response.error.code).to.eq(111)
-          expect(response.error.message)
-            .to.eq('Required parameter "accessToken" is invalid.')
+            expect(status).to.eq(401)
+            expect(response.error.code).to.eq(111)
+            expect(response.error.message)
+              .to.eq('Required parameter "accessToken" is invalid.')
 
-          done()
-        })
+            done()
+          })
+      })
     })
-  })
 
-  describe('without an access token', () => {
-    it('returns a 403 with an error object', (done) => {
-      const params = {
-        params: {
-          MetricData: [
-            {
-              MetricName: 'HELLO_WORLD',
-              Value: 100,
-            }
-          ],
-          Namespace: 'cloudwatch-postman',
+    describe('without an access token', () => {
+      it('returns a 403 with an error object', (done) => {
+        const params = {
+          params: {
+            MetricData: [
+              {
+                MetricName: 'HELLO_WORLD',
+                Value: 100,
+              }
+            ],
+            Namespace: 'cloudwatch-postman',
+          }
         }
-      }
 
-      chai.request(server)
-        .post('/metric')
-        .set('Content-Type', 'application/json')
-        .send(JSON.stringify(params))
-        .end((err, res) => {
-          const { status, body } = res
-          const response = JSON.parse(body)
+        chai.request(server)
+          .post('/metric')
+          .set('Content-Type', 'application/json')
+          .send(JSON.stringify(params))
+          .end((err, res) => {
+            const { status, body } = res
+            const response = JSON.parse(body)
 
-          expect(status).to.eq(403)
-          expect(response.error.code).to.eq(110)
-          expect(response.error.message)
-            .to.eq('Required parameter is missing: "accessToken".')
+            expect(status).to.eq(403)
+            expect(response.error.code).to.eq(110)
+            expect(response.error.message)
+              .to.eq('Required parameter is missing: "accessToken".')
 
-          done()
-        })
+            done()
+          })
+      })
     })
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -2,10 +2,26 @@ import chai, { expect } from 'chai'
 import chaiHttp from 'chai-http'
 import server from './../lib/index'
 import AWS from 'aws-sdk-mock'
+import {
+  generateSalt,
+  generateHash,
+  generateToken,
+  createAccessToken,
+} from '../lib/token'
 
 global.chai = chai
 global.expect = expect
 chai.use(chaiHttp)
+
+export const createTestAppToken = () => {
+  const date = new Date().getTime()
+  const salt = generateSalt(8)
+  const secret = process.env.CLOUDWATCH_POSTMAN_SECRET_KEY
+  const delimiter = '::'
+  const hash = generateHash(`${date}${salt}${secret}`)
+
+  return generateToken([date, salt, secret], delimiter)
+}
 
 beforeEach(() => {
   AWS.mock('CloudWatch', 'putMetricData', function (params, callback){
@@ -19,8 +35,9 @@ afterEach(() => {
 
 describe('GET /test', () => {
   it('returns a response', (done) => {
+    const appToken = createTestAppToken()
     chai.request(server)
-      .get('/test')
+      .get(`/test?appToken=${appToken}`)
       .end((err, res) => {
         expect(res.status).to.eq(200)
         expect(JSON.parse(res.body)).to.eq('ok')
@@ -31,14 +48,18 @@ describe('GET /test', () => {
 
 describe('POST /metric', () => {
   it('returns a response', (done) => {
+    const accessToken = createAccessToken()
     const params = {
-      MetricData: [
-        {
-          MetricName: 'HELLO_WORLD',
-          Value: 100,
-        }
-      ],
-      Namespace: 'cloudwatch-postman',
+      accessToken,
+      params: {
+        MetricData: [
+          {
+            MetricName: 'HELLO_WORLD',
+            Value: 100,
+          }
+        ],
+        Namespace: 'cloudwatch-postman',
+      }
     }
 
     chai.request(server)

--- a/test/token.js
+++ b/test/token.js
@@ -1,0 +1,232 @@
+import chai, { expect } from 'chai'
+import sinon from 'sinon'
+import sinonChai from 'sinon-chai'
+import AWS from 'aws-sdk-mock'
+import {
+  generateSalt,
+  generateHash,
+  generateToken,
+  isTokenExpired,
+  isAppTokenValid,
+  isAccessTokenValid,
+  createAccessToken,
+} from '../lib/token'
+import { createTestAppToken } from './index'
+
+global.chai = chai
+global.expect = expect
+chai.use(sinonChai)
+
+const crypto = require('crypto')
+describe('========== token.js ==========', () => {
+  let sandbox
+
+  before(() => sandbox = sinon.createSandbox())
+  afterEach(() => sandbox.restore())
+
+  describe('generateSalt', () => {
+    it('returns a string', () => {
+      const toStringSpy = sandbox.spy()
+      const stubbedRandomBytes = sandbox
+        .stub(crypto, 'randomBytes')
+        .returns({ toString: toStringSpy })
+
+      generateSalt(10)
+      expect(stubbedRandomBytes).to.have.been.calledWith(10)
+      expect(toStringSpy).to.have.been.calledWith('hex')
+    })
+  })
+
+  describe('generateHash', () => {
+    it('returns a string', () => {
+      const updateSpy = sandbox.spy()
+      const stubbedCreateHash = sandbox
+        .stub(crypto, 'createHash')
+        .returns({ update: updateSpy })
+
+      generateHash('Alice in Wonderland')
+      expect(stubbedCreateHash).to.have.been.calledWith('sha256')
+      expect(updateSpy).to.have.been.calledWith('Alice in Wonderland')
+    })
+  })
+
+  describe('generateToken', () => {
+    it('returns a string', () => {
+      const toStringSpy = sandbox.spy()
+      const stubbedFrom = sandbox
+        .stub(Buffer, 'from')
+        .returns({ toString: toStringSpy })
+
+      generateToken(['alice', 'in', 'wonderland'], '-')
+      expect(stubbedFrom).to.have.been.calledWith('alice-in-wonderland')
+      expect(toStringSpy).to.have.been.calledWith('base64')
+    })
+  })
+
+  describe('isTokenExpired', () => {
+    describe('without expiration parameter', () => {
+      describe('when token is expired', () => {
+        it('returns true', () => {
+          const today = new Date()
+          const expiredTokenDate = new Date()
+          expiredTokenDate.setDate(today.getDate() - 2)
+          const expiredTokenTime = expiredTokenDate.getTime()
+
+          expect(isTokenExpired(expiredTokenTime)).to.eq(true)
+        })
+      })
+
+      describe('when token is valid', () => {
+        it('returns true', () => {
+          const validTokenDate = new Date()
+          const validTokenTime = validTokenDate.getTime()
+
+          expect(isTokenExpired(validTokenTime)).to.eq(false)
+        })
+      })
+    })
+
+    describe('with expiration parameter', () => {
+      describe('when token is expired', () => {
+        it('returns true', () => {
+          const today = new Date()
+          const expiredTokenDate = new Date()
+          expiredTokenDate.setHours(today.getHours() - 2)
+          const expiredTokenTime = expiredTokenDate.getTime()
+
+          expect(isTokenExpired(expiredTokenTime, { hour: 1 })).to.eq(true)
+        })
+      })
+
+      describe('when token is valid', () => {
+        it('returns true', () => {
+          const validTokenDate = new Date()
+          const validTokenTime = validTokenDate.getTime()
+
+          expect(isTokenExpired(validTokenTime, { hour: 1 })).to.eq(false)
+        })
+      })
+    })
+  })
+
+  describe('isAccessTokenValid', () => {
+    describe('when access token is expired', () => {
+      it('returns false', () => {
+        const createTestAccessToken = () => {
+          const today = new Date()
+          const expiredTokenDate = new Date()
+          expiredTokenDate.setDate(today.getDate() - 2)
+          const expiredTokenTime = expiredTokenDate.getTime()
+          const salt = generateSalt(12)
+          const secret = process.env.ACCESS_TOKEN_SECRET_KEY
+          const delimiter = '::'
+          const hash = generateHash(`${expiredTokenTime}${salt}${secret}`)
+
+          return generateToken([expiredTokenTime, salt, secret], delimiter)
+        }
+        const token = createTestAccessToken()
+
+        expect(isAccessTokenValid(token)).to.eq(false)
+      })
+    })
+
+    describe('when access token is valid', () => {
+      describe('with a correct secret', () => {
+        it('returns true', () => {
+          const token = createAccessToken()
+
+          expect(isAccessTokenValid(token)).to.eq(true)
+        })
+      })
+
+      describe('with a wrong secret', () => {
+        it('returns false', () => {
+          const createTestAccessToken = () => {
+            const today = new Date()
+            const tokenTime = today.getTime()
+            const salt = generateSalt(12)
+            const secret = 'wrong-secret'
+            const delimiter = '::'
+            const hash = generateHash(`${tokenTime}${salt}${secret}`)
+
+            return generateToken([tokenTime, salt, secret], delimiter)
+          }
+          const token = createTestAccessToken()
+
+          expect(isAccessTokenValid(token)).to.eq(false)
+        })
+      })
+
+      describe('with tampered data', () => {
+        it('returns false', () => {
+          const token = 'alice-in-wonderland'
+
+          expect(isAccessTokenValid(token)).to.eq(false)
+        })
+
+      })
+    })
+  })
+
+  describe('isAppTokenValid', () => {
+    describe('when access token is expired', () => {
+      it('returns false', () => {
+        const createExpiredAppAccessToken = () => {
+          const today = new Date()
+          const expiredTokenDate = new Date()
+          expiredTokenDate.setDate(today.getDate() - 2)
+          const expiredTokenTime = expiredTokenDate.getTime()
+          const salt = generateSalt(8)
+          const secret = process.env.APP_SECRET_KEY
+          const delimiter = '::'
+          const hash = generateHash(`${expiredTokenTime}${salt}${secret}`)
+
+          return generateToken([expiredTokenTime, salt, secret], delimiter)
+        }
+        const token = createExpiredAppAccessToken()
+
+        expect(isAppTokenValid(token)).to.eq(false)
+      })
+    })
+
+    describe('when access token is valid', () => {
+      describe('with a correct secret', () => {
+        it('returns true', () => {
+          const token = createTestAppToken()
+
+          expect(isAppTokenValid(token)).to.eq(true)
+        })
+      })
+
+      describe('with a wrong secret', () => {
+        it('returns false', () => {
+        const createWrongAppAccessToken = () => {
+          const today = new Date()
+          const tokenTime = today.getTime()
+          const salt = generateSalt(8)
+          const secret = 'wrong-secret'
+          const delimiter = '::'
+          const hash = generateHash(`${tokenTime}${salt}${secret}`)
+
+          return generateToken([tokenTime, salt, secret], delimiter)
+        }
+        const token = createWrongAppAccessToken()
+
+          expect(isAppTokenValid(token)).to.eq(false)
+        })
+      })
+
+      describe('with tampered data', () => {
+        it('returns false', () => {
+          const token = 'alice-in-wonderland'
+
+          expect(isAppTokenValid(token)).to.eq(false)
+        })
+      })
+    })
+  })
+
+  describe('createAccessToken', () => {
+
+  })
+})


### PR DESCRIPTION
This PR adds two barriers to possible attacks: 
- authorize POST requests only with an access token,
- fetch access token only with a generated app token (created with a shared secret between the app and the consumer).