### PR TITLE
[API] Add an endpoint to create log events in CloudWatch

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -137,6 +137,44 @@ server.post('/metric', (req, res, next) => {
   return next()
 })
 
+server.post('/logEvents', (req, res, next) => {
+  const { body: { accessToken } } = req
+
+  if (!accessToken) {
+    res.json(403, {
+      error: {
+        code: 110,
+        message: 'Required parameter is missing: "accessToken".',
+      }
+    })
+    return next()
+  }
+
+  if (!isAccessTokenValid(accessToken)) {
+    res.json(401, {
+      error: {
+        code: 111,
+        message: 'Required parameter "accessToken" is invalid.',
+      }
+    })
+    return next()
+  }
+
+  const cloudwatchLogs = new AWS.CloudWatchLogs({
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    region: process.env.AWS_REGION,
+  })
+
+  cloudwatchLogs.putLogEvents(req.body.params, (err, data) => {
+    if (err) return console.log(err, err.stack)
+
+    res.json(201, data)
+  })
+
+  return next()
+})
+
 server.listen(port, () => {
   console.log('%s listening at %s', server.name, server.url)
 })

--- a/test/index.js
+++ b/test/index.js
@@ -253,5 +253,73 @@ describe('=========== index.js ==========', () => {
       })
     })
 
+    describe('with an invalid access token', () => {
+      it('returns a 401 with an error object', (done) => {
+        const accessToken = 'aliceInWonderland'
+
+        const params = {
+          accessToken,
+          params: {
+            logGroupName: 'RUM',
+            logStreamName: 'cloudwatch-postman-test',
+            logEvents: [
+              {
+                message: 'This is a test.',
+                timestamp: '1558602946107',
+              },
+            ],
+            sequenceToken: 'the-cheshire-cat',
+          },
+        }
+
+        chai.request(server)
+          .post('/logEvents')
+          .set('Content-Type', 'application/json')
+          .send(JSON.stringify(params))
+          .end((err, res) => {
+            const { status, body } = res
+
+            expect(status).to.eq(401)
+            expect(body.error.code).to.eq(111)
+            expect(body.error.message)
+              .to.eq('Required parameter "accessToken" is invalid.')
+
+            done()
+          })
+      })
+    })
+
+    describe('without an access token', () => {
+      it('returns a 403 with an error object', (done) => {
+        const params = {
+          params: {
+            logGroupName: 'RUM',
+            logStreamName: 'cloudwatch-postman-test',
+            logEvents: [
+              {
+                message: 'This is a test.',
+                timestamp: '1558602946107',
+              },
+            ],
+            sequenceToken: 'the-cheshire-cat',
+          },
+        }
+
+        chai.request(server)
+          .post('/logEvents')
+          .set('Content-Type', 'application/json')
+          .send(JSON.stringify(params))
+          .end((err, res) => {
+            const { status, body } = res
+
+            expect(status).to.eq(403)
+            expect(body.error.code).to.eq(110)
+            expect(body.error.message)
+              .to.eq('Required parameter is missing: "accessToken".')
+
+            done()
+          })
+      })
+    })
   })
 })


### PR DESCRIPTION
Suite à quelques autres tests avec CloudWatch et une réflexion sur les métriques à suivre, il me semble plus intéressant d'enregistrer des logs dans CloudWatch et de créer des filtres de métriques à la mano plutôt que de publier directement des métriques. 

Grosso modo :
- les métriques sont des données formatées,
- les logs sont des données brutes (=> plus de flexibilité pour les exploiter)

J'ai donc ajouté un nouveau endpoint sur l'API. Il y a pas mal de duplication de code, je ferai du refacto dans une PR ultérieure.
