### PR TITLE
[API] Add CORS handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+Feature:
+- [#20](https://github.com/KissKissBankBank/cloudwatch-postman/pull/20) - Add
+  CORS handling on API endpoints
+
 ## [3.1.0](https://github.com/KissKissBankBank/cloudwatch-postman/compare/v3.0.0...v3.1.0) - 2019-05-23
 
 - [#18](https://github.com/KissKissBankBank/cloudwatch-postman/pull/18) - Add an endpoint `POST /logEvents` to create log events in CloudWatch

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,8 +16,10 @@ const globalThrottleOptions = {
   ip: true,   // throttle per IP
 }
 
+const allowedOrigins = process.env.CORS_ALLOWED_ORIGIN || '*'
+
 const cors = corsMiddleware({
-  origins: process.env.CORS_ALLOWED_ORIGIN.split(','),
+  origins: allowedOrigins.split(','),
 })
 
 server.pre(cors.preflight)

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ import {
   isAccessTokenValid,
   createAccessToken,
 } from './token'
+import corsMiddleware from 'restify-cors-middleware'
 
 const isProduction = process.env.NODE_ENV === 'production'
 const server = restify.createServer()
@@ -15,6 +16,12 @@ const globalThrottleOptions = {
   ip: true,   // throttle per IP
 }
 
+const cors = corsMiddleware({
+  origins: process.env.CORS_ALLOWED_ORIGIN.split(','),
+})
+
+server.pre(cors.preflight)
+server.use(cors.actual)
 server.use(restify.plugins.bodyParser())
 server.use(restify.plugins.queryParser());
 if (isProduction) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4173,6 +4173,14 @@
         "vasync": "^2.2.0"
       }
     },
+    "restify-cors-middleware": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/restify-cors-middleware/-/restify-cors-middleware-1.1.1.tgz",
+      "integrity": "sha1-BmiFAvoIuMYngxA4RMh9z8MNzz4=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "restify-errors": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/restify-errors/-/restify-errors-8.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "aws-sdk": "^2.457.0",
     "dotenv": "^8.0.0",
     "request": "^2.88.0",
-    "restify": "^8.3.2"
+    "restify": "^8.3.2",
+    "restify-cors-middleware": "^1.1.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",


### PR DESCRIPTION
J'ai ajouté un middleware pour gérer le CORS dans les appels à l'API. Les hôtes autorisés peuvent être passés via une variable d'environnement `CORS_ALLOWED_ORIGIN`.