### PR TITLE
[Stability] Change client secret key name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+Breaking change:
+- [#21](https://github.com/KissKissBankBank/cloudwatch-postman/pull/21) - Change
+  the configuration variable `APP_SECRET_KEY` into `CLIENT_SECRET_KEY`
+
 ## [3.1.0](https://github.com/KissKissBankBank/cloudwatch-postman/compare/v3.0.0...v3.1.0) - 2019-05-23
 
 - [#18](https://github.com/KissKissBankBank/cloudwatch-postman/pull/18) - Add an endpoint `POST /logEvents` to create log events in CloudWatch

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ Install the dependencies:
 npm install
 ```
 
-Choose an `APP_SECRET_KEY` and an `ACCESS_TOKEN_SECRET_KEY`. These secret values
+Choose an `CLIENT_SECRET_KEY` and an `ACCESS_TOKEN_SECRET_KEY`. These secret values
 will be used by CloudWatch Postman to generate tokens to access the API.
 
 Use these secrets and your AWS credentials as environment variables to start
 the app:
 
 ```sh
-APP_SECRET_KEY=*** ACCESS_TOKEN_SECRET_KEY=*** AWS_ACCESS_KEY_ID=*** AWS_SECRET_ACCESS_KEY=*** AWS_REGION=*** npm start
+CLIENT_SECRET_KEY=*** ACCESS_TOKEN_SECRET_KEY=*** AWS_ACCESS_KEY_ID=*** AWS_SECRET_ACCESS_KEY=*** AWS_REGION=*** npm start
 ```
 
 Test the API on [http://localhost:8080/test](http://localhost:8080/test).
@@ -81,7 +81,7 @@ token for the API.
 You will needs these values:
 - the current timestamp,
 - a random salt value,
-- your `APP_SECRET_KEY`,
+- your `CLIENT_SECRET_KEY`,
 
 Concatenate these 3 values and hash them with a `sha256` algorithm digested in
 `base64`. Here is an
@@ -123,7 +123,7 @@ npm run serve
 AWS_ACCESS_KEY_ID=***
 AWS_SECRET_ACCESS_KEY=***
 AWS_REGION=***
-APP_SECRET_KEY=***
+CLIENT_SECRET_KEY=***
 ACCESS_TOKEN_SECRET_KEY=***
 ```
 
@@ -136,7 +136,7 @@ Variable | Requirement | Description | Default value
 `AWS_ACCESS_KEY_ID` | *Required* | The AWS IAM user access key id. |
 `AWS_SECRET_ACCESS_KEY` | *Required* | The AWS IAM user secret access key. |
 `AWS_REGION` | *Required* | The CloudWatch region |
-`APP_SECRET_KEY` | *Required* | Your app secret key. You will share it on your consumer app to generate your application token. |
+`CLIENT_SECRET_KEY` | *Required* | Your client secret key. You will share it on your consumer app to generate your client token. |
 `ACCESS_TOKEN_SECRET_KEY` | *Required* | Your access token secret key. It is used to generate all the access tokens. |
 `PORT` | *Optional* | The port on which the server is lauched | `8080`
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ credentials.
   - [What is a unique access token?](#what-is-a-unique-access-token)
   - [When is a unique access token used?](#when-is-a-unique-access-token-used)
   - [How to get a unique access token?](#how-to-get-a-unisque-access-token)
-  - [How to generate your application
-    token](#how-to-generate-your-application-token)
+  - [How to generate your client token](#how-to-generate-your-client-token)
 - [API](#api)
 - [Configuration with Dotenv](#configuration-with-dotenv)
 - [Contributing](#contributing)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You can request the API using a unique access token.
 
 As CloudWatch Postman is firstly meant to be called by a client-side
 application, unique access tokens can secure a little bit more the API endpoints.
-You need to exchange your [application token](#create-your-application-token) to
+You need to exchange your [client token](#how-to-generate-your-client-token) to
 obtain a unique access token. This latter have a default expiration of one
 hour.
 
@@ -70,7 +70,7 @@ possible if you know that you will need to query the API.
 ### How to get a unique access token?
 
 You can fetch an `accessToken` on the `POST /token` endpoint with your
-[application token](#how-to-generate-your-application-token).
+[client token](#how-to-generate-your-client-token).
 
 ### How to generate your client token
 

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ possible if you know that you will need to query the API.
 You can fetch an `accessToken` on the `POST /token` endpoint with your
 [application token](#how-to-generate-your-application-token).
 
-### How to generate your application token
+### How to generate your client token
 
-This section explains how to generate an application token to request an access
+This section explains how to generate an client token to request an access
 token for the API.
 
 You will needs these values:

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ import restify from 'restify'
 import AWS from 'aws-sdk'
 import request from 'request'
 import {
-  isAppTokenValid,
+  isClientTokenValid,
   isAccessTokenValid,
   createAccessToken,
 } from './token'
@@ -22,17 +22,17 @@ if (isProduction) {
 }
 const port = process.env.PORT || 8080
 
-const invalidAppTokenErrorBody = {
+const invalidClientTokenErrorBody = {
   error: {
     code: 101,
-    message: 'Required parameter "appToken" is invalid.',
+    message: 'Required parameter "clientToken" is invalid.',
   },
 }
 
-const noAppTokenErrorBody = {
+const noClientTokenErrorBody = {
   error: {
     code: 100,
-    message: 'Required parameter is missing: "appToken".',
+    message: 'Required parameter is missing: "clientToken".',
   },
 }
 
@@ -81,15 +81,15 @@ if (isProduction) {
 }
 
 server.post('/token', (req, res, next) => {
-  if (!req.body || !req.body.appToken) {
-    res.json(403, noAppTokenErrorBody)
+  if (!req.body || !req.body.clientToken) {
+    res.json(403, noClientTokenErrorBody)
     return next()
   }
 
-  const appToken = req.body.appToken
+  const clientToken = req.body.clientToken
 
-  if (!isAppTokenValid(appToken)) {
-    res.json(401, invalidAppTokenErrorBody)
+  if (!isClientTokenValid(clientToken)) {
+    res.json(401, invalidClientTokenErrorBody)
     return next()
   }
 

--- a/lib/token.js
+++ b/lib/token.js
@@ -41,7 +41,7 @@ export const isAccessTokenValid = (token) => {
   return apiHash == hash
 }
 
-export const isAppTokenValid = (token) => {
+export const isClientTokenValid = (token) => {
   const data = Buffer.from(token, 'base64')
   const decodedData = data.toString('ascii')
   const apiSecret = process.env.CLIENT_SECRET_KEY

--- a/lib/token.js
+++ b/lib/token.js
@@ -44,7 +44,7 @@ export const isAccessTokenValid = (token) => {
 export const isAppTokenValid = (token) => {
   const data = Buffer.from(token, 'base64')
   const decodedData = data.toString('ascii')
-  const apiSecret = process.env.APP_SECRET_KEY
+  const apiSecret = process.env.CLIENT_SECRET_KEY
 
   const [ date, salt, hash ] = decodedData.split('::')
 

--- a/test/index.js
+++ b/test/index.js
@@ -13,7 +13,7 @@ global.chai = chai
 global.expect = expect
 chai.use(chaiHttp)
 
-export const createTestAppToken = () => {
+export const createTestClientToken = () => {
   const date = new Date().getTime()
   const salt = generateSalt(8)
   const secret = process.env.CLIENT_SECRET_KEY
@@ -36,10 +36,8 @@ describe('=========== index.js ==========', () => {
 
   describe('GET /test', () => {
     it('returns a 200 with a data object', (done) => {
-      const appToken = createTestAppToken()
-
       chai.request(server)
-        .get(`/test?appToken=${appToken}`)
+        .get(`/test`)
         .end((err, res) => {
           const { status, body } = res
 
@@ -54,12 +52,12 @@ describe('=========== index.js ==========', () => {
   describe('POST /token', () => {
     describe('with a valid app token', () => {
       it('returns a 201 with the newly created access token', (done) => {
-        const appToken = createTestAppToken()
+        const clientToken = createTestClientToken()
 
         chai.request(server)
           .post('/token')
           .set('Content-Type', 'application/json')
-          .send(JSON.stringify({ appToken }))
+          .send(JSON.stringify({ clientToken }))
           .end((err, res) => {
             const { status, body } = res
 
@@ -73,19 +71,19 @@ describe('=========== index.js ==========', () => {
 
     describe('with an invalid app token', () => {
       it('returns a 401 with an error object', (done) => {
-        const appToken = 'aliceInWonderland'
+        const clientToken = 'aliceInWonderland'
 
         chai.request(server)
           .post('/token')
           .set('Content-Type', 'application/json')
-          .send(JSON.stringify({ appToken }))
+          .send(JSON.stringify({ clientToken }))
           .end((err, res) => {
             const { status, body } = res
 
             expect(status).to.eq(401)
             expect(body.error.code).to.eq(101)
             expect(body.error.message)
-              .to.eq('Required parameter "appToken" is invalid.')
+              .to.eq('Required parameter "clientToken" is invalid.')
 
             done()
           })
@@ -103,7 +101,7 @@ describe('=========== index.js ==========', () => {
             expect(status).to.eq(403)
             expect(body.error.code).to.eq(100)
             expect(body.error.message)
-              .to.eq('Required parameter is missing: "appToken".')
+              .to.eq('Required parameter is missing: "clientToken".')
 
             done()
           })

--- a/test/index.js
+++ b/test/index.js
@@ -16,7 +16,7 @@ chai.use(chaiHttp)
 export const createTestAppToken = () => {
   const date = new Date().getTime()
   const salt = generateSalt(8)
-  const secret = process.env.APP_SECRET_KEY
+  const secret = process.env.CLIENT_SECRET_KEY
   const delimiter = '::'
   const hash = generateHash(`${date}${salt}${secret}`)
 

--- a/test/token.js
+++ b/test/token.js
@@ -6,11 +6,11 @@ import {
   generateHash,
   generateToken,
   isTokenExpired,
-  isAppTokenValid,
+  isClientTokenValid,
   isAccessTokenValid,
   createAccessToken,
 } from '../lib/token'
-import { createTestAppToken } from './index'
+import { createTestClientToken } from './index'
 
 global.chai = chai
 global.expect = expect
@@ -171,7 +171,7 @@ describe('========== token.js ==========', () => {
     })
   })
 
-  describe('isAppTokenValid', () => {
+  describe('isClientTokenValid', () => {
     describe('when access token is expired', () => {
       it('returns false', () => {
         const createExpiredAppAccessToken = () => {
@@ -188,16 +188,16 @@ describe('========== token.js ==========', () => {
         }
         const token = createExpiredAppAccessToken()
 
-        expect(isAppTokenValid(token)).to.eq(false)
+        expect(isClientTokenValid(token)).to.eq(false)
       })
     })
 
     describe('when access token is valid', () => {
       describe('with a correct secret', () => {
         it('returns true', () => {
-          const token = createTestAppToken()
+          const token = createTestClientToken()
 
-          expect(isAppTokenValid(token)).to.eq(true)
+          expect(isClientTokenValid(token)).to.eq(true)
         })
       })
 
@@ -215,7 +215,7 @@ describe('========== token.js ==========', () => {
         }
         const token = createWrongAppAccessToken()
 
-          expect(isAppTokenValid(token)).to.eq(false)
+          expect(isClientTokenValid(token)).to.eq(false)
         })
       })
 
@@ -223,7 +223,7 @@ describe('========== token.js ==========', () => {
         it('returns false', () => {
           const token = 'alice-in-wonderland'
 
-          expect(isAppTokenValid(token)).to.eq(false)
+          expect(isClientTokenValid(token)).to.eq(false)
         })
       })
     })

--- a/test/token.js
+++ b/test/token.js
@@ -180,7 +180,7 @@ describe('========== token.js ==========', () => {
           expiredTokenDate.setDate(today.getDate() - 2)
           const expiredTokenTime = expiredTokenDate.getTime()
           const salt = generateSalt(8)
-          const secret = process.env.APP_SECRET_KEY
+          const secret = process.env.CLIENT_SECRET_KEY
           const delimiter = '::'
           const hash = generateHash(`${expiredTokenTime}${salt}${secret}`)
 


### PR DESCRIPTION
Dans cette PR, je change le nom de la clé qui permet au client de créer sa clé secrète. Au lieu de `APP_SECRET_KEY` qui est légèrement ambigü, je le change en `CLIENT_SECRET_KEY` pour expliciter que c'est la clé qui sert au consommateur de l'API.