### PR TITLE
[LogEvents] Use REDIS_URL environment variable to setup Bull queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+Fix:
+- [#27](https://github.com/KissKissBankBank/cloudwatch-postman/pull/27) - Use
+  `REDIS_URL` environment variable to instanciate Bull queues
+
 ## [4.0.0](https://github.com/KissKissBankBank/cloudwatch-postman/compare/v3.0.0...v4.0.0) - 2019-06-12
 
 Breaking changes:

--- a/lib/index.js
+++ b/lib/index.js
@@ -170,7 +170,7 @@ server.post('/logEvents', (req, res, next) => {
     return next()
   }
 
-  const logEventsQueue = new Queue('logEvents')
+  const logEventsQueue = new Queue('logEvents', process.env.REDIS_URL)
   const params = {
     logGroupName,
     logStreamName,

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,7 +1,7 @@
 import Queue from 'bull'
 import { processor } from './log-events-processor'
 
-const logEventsQueue = new Queue('logEvents')
+const logEventsQueue = new Queue('logEvents', process.env.REDIS_URL)
 
 logEventsQueue.process(processor)
 


### PR DESCRIPTION
J'ai oublié d'ajouter la variable d'environnement `REDIS_URL` pour instancier les queues Bull. Du coup, en production, ça tente de se connecter sur `redis://127.0.0.1:6379` (ce qui ne fonctionne pas évidemment). 

Cette PR corrige ce petit bug.

cf. https://github.com/OptimalBits/bull/blob/master/REFERENCE.md#queue