### PR TITLE
[Performance] Clean and reuse Redis connections when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+Fix:
+- [#30]https://github.com/KissKissBankBank/cloudwatch-postman/pull/30() - Clean
+  and reuse Redis connections when possible
+
 ## [4.0.1](https://github.com/KissKissBankBank/cloudwatch-postman/compare/v4.0.0...v4.0.1) - 2019-06-12
 
 Fix:

--- a/lib/index.js
+++ b/lib/index.js
@@ -177,7 +177,11 @@ server.post('/logEvents', (req, res, next) => {
     logEvents,
   }
 
-  logEventsQueue.add(params, { attempts: 3 })
+  logEventsQueue.add(params, {
+    attempts: 3,
+    removeOnComplete: true,
+    removeOnFail: true,
+  })
 
   res.json(201)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -181,7 +181,6 @@ server.post('/logEvents', (req, res, next) => {
   logEventsQueue.add(params, {
     attempts: 3,
     removeOnComplete: true,
-    removeOnFail: true,
   })
 
   res.json(201)

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ import {
 } from './token'
 import corsMiddleware from 'restify-cors-middleware'
 import Queue from 'bull'
+import { logEventsQueueOptions } from './log-events-processor'
 
 const isProduction = process.env.NODE_ENV === 'production'
 const server = restify.createServer()
@@ -170,7 +171,7 @@ server.post('/logEvents', (req, res, next) => {
     return next()
   }
 
-  const logEventsQueue = new Queue('logEvents', process.env.REDIS_URL)
+  const logEventsQueue = new Queue('logEvents', logEventsQueueOptions)
   const params = {
     logGroupName,
     logStreamName,

--- a/lib/log-events-processor.js
+++ b/lib/log-events-processor.js
@@ -104,3 +104,19 @@ export const processor = (job, done) => {
     .then(saveRefetchedToken(job, done))
     .catch(handleCloudWatchLogsError(done))
 }
+
+const client = new Redis(process.env.REDIS_URL);
+const subscriber = new Redis(process.env.REDIS_URL);
+
+export const logEventsQueueOptions = {
+  createClient: (type) => {
+    switch (type) {
+      case 'client':
+        return client;
+      case 'subscriber':
+        return subscriber;
+      default:
+        return new Redis();
+    }
+  }
+}

--- a/lib/log-events-processor.js
+++ b/lib/log-events-processor.js
@@ -4,18 +4,30 @@ import {
   cloudwatchDescribeLogStreams,
 } from './cloudwatch-logs'
 
-const redis = new Redis(process.env.REDIS_URL)
+const memoizeRedis = () => {
+  let memo
+
+  return () => {
+    if (memo) return memo
+
+    memo = new Redis(process.env.REDIS_URL)
+
+    return memo
+  }
+}
+
+const getRedis = memoizeRedis()
 
 export const tokenKey = (logGroupName, logStreamName) => (
   `${logGroupName}-${logStreamName}-next-token`
 )
 
 export const getValidSequenceToken = (logGroupName, logStreamName) => (
-  redis.get(tokenKey(logGroupName, logStreamName))
+  getRedis().get(tokenKey(logGroupName, logStreamName))
 )
 
 export const saveValidSequenceToken = (token, logGroupName, logStreamName) => (
-  redis.set(tokenKey(logGroupName, logStreamName), token)
+  getRedis().set(tokenKey(logGroupName, logStreamName), token)
 )
 
 export const putLogEvents = job => token => {

--- a/lib/log-events-processor.js
+++ b/lib/log-events-processor.js
@@ -117,7 +117,7 @@ export const getQueueCreateClient = (client, subscriber) => {
       case 'subscriber':
         return subscriber
       default:
-        return new Redis()
+        return new Redis(process.env.REDIS_URL)
     }
   }
 }

--- a/lib/log-events-processor.js
+++ b/lib/log-events-processor.js
@@ -4,7 +4,7 @@ import {
   cloudwatchDescribeLogStreams,
 } from './cloudwatch-logs'
 
-const memoizeRedis = () => {
+export const memoizeRedis = () => {
   let memo
 
   return () => {
@@ -108,15 +108,20 @@ export const processor = (job, done) => {
 const client = new Redis(process.env.REDIS_URL);
 const subscriber = new Redis(process.env.REDIS_URL);
 
-export const logEventsQueueOptions = {
-  createClient: (type) => {
+// cf. https://github.com/OptimalBits/bull/blob/master/PATTERNS.md#reusing-redis-connections
+export const getQueueCreateClient = (client, subscriber) => {
+  return (type) => {
     switch (type) {
       case 'client':
-        return client;
+        return client
       case 'subscriber':
-        return subscriber;
+        return subscriber
       default:
-        return new Redis();
+        return new Redis()
     }
   }
+}
+
+export const logEventsQueueOptions = {
+  createClient: getQueueCreateClient(client, subscriber),
 }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,7 +1,7 @@
 import Queue from 'bull'
-import { processor } from './log-events-processor'
+import { processor, logEventsQueueOptions } from './log-events-processor'
 
-const logEventsQueue = new Queue('logEvents', process.env.REDIS_URL)
+const logEventsQueue = new Queue('logEvents', logEventsQueueOptions)
 
 logEventsQueue.process(processor)
 


### PR DESCRIPTION
### Description

[Performance] Nettoie et réutilise les connexions Redis lorsque c'est possible

### Pourquoi

ClickUp : https://app.clickup.com/t/12nxg0

Actuellement, on ouvre plusieurs nouvelles connexions Redis (qu'on ne ferme jamais) pour chaque appel à CloudWatch Postman sur le endpoint `/eventLogs`. L'instance Redis en prod est servie par Heroku dont la limite de connexion est de 20. On arrive donc au bout de 20 appels à l'erreur suivante : 
```
[ioredis] Unhandled error event: ReplyError: ERR max number of clients reached
```

### Détails 

La présente PR ajoute donc : 
- une gestion de la réutilisation de la connexion Redis utilisée pour récupérer et enregistrer le `nextSequenceToken`,
- une gestion de la réutilisation des connexions Redis nécessaires à la création d'une queue (cf. 
https://github.com/OptimalBits/bull/blob/master/PATTERNS.md#reusing-redis-connections),
- un nettoyage automatique des jobs qui ont réussi.

J'ai checké que le nombre de connexions restait le même après plusieurs calls sur le endpoint `/logEvents` via le cli de Redis avec la commande `CLIENT LIST`. Ça a l'air d'être ok avec la PR.

### Todos

- [x] Tests unitaires